### PR TITLE
add Default trait implementations for circuit breakers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 ### UNRELEASED
 
 Breaking changes:
-
 * `success_rate` policy now accepts `min_request_threshold`.
 
 Improvements:
-
+* add `CircuitBreaker::default()`
 * remove `tokio-timer` dependency.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ fn dangerous_call() -> Result<(), ()> {
 
 // Create a circuit breaker which configured by reasonable default backoff and
 // failure accrual policy.
-let circuit_breaker = CircuitBreaker::builder().build();
+let circuit_breaker = CircuitBreaker::default();
 
 // Call the function in a loop, after some iterations the circuit breaker will
 // be in a open state and reject next calls.
@@ -84,6 +84,5 @@ let policy = failure_policy::consecutive_failures(3, backoff);
 let circuit_breaker = CircuitBreaker::builder()
   .failure_policy(policy)
   .build();
-
 ```
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Or configure custom backoff and policy:
 use std::time::Duration;
 use failsafe::{backoff, failure_policy, CircuitBreaker};
 
-// Create an exponential growth backoff which starts from 5s and ends with 60s.
+// Create an exponential growth backoff which starts from 10s and ends with 60s.
 let backoff = backoff::exponential(Duration::from_secs(10), Duration::from_secs(60));
 
 // Create a policy which failed when three consecutive failures were made.

--- a/src/circuit_breaker.rs
+++ b/src/circuit_breaker.rs
@@ -56,6 +56,20 @@ impl CircuitBreaker<(), ()> {
     }
 }
 
+impl Default
+    for CircuitBreaker<
+        failure_policy::OrElse<
+            SuccessRateOverTimeWindow<backoff::EqualJittered>,
+            ConsecutiveFailures<backoff::EqualJittered>,
+        >,
+        NoopInstrument,
+    >
+{
+    fn default() -> Self {
+        CircuitBreaker::builder().build()
+    }
+}
+
 impl<POLICY, INSTRUMENT> CircuitBreaker<POLICY, INSTRUMENT>
 where
     POLICY: FailurePolicy,

--- a/src/futures/mod.rs
+++ b/src/futures/mod.rs
@@ -25,7 +25,7 @@
 //!
 //! // Create a circuit breaker which configured by reasonable default backoff and
 //! // failure accrual policy.
-//! let circuit_breaker = CircuitBreaker::builder().build();
+//! let circuit_breaker = CircuitBreaker::default();
 //!
 //! // Wraps `dangerous_call` result future within circuit breaker.
 //! let future = circuit_breaker.call(dangerous_call());
@@ -103,6 +103,20 @@ impl CircuitBreaker<(), ()> {
         Tag,
     > {
         Config::new()
+    }
+}
+
+impl Default
+    for CircuitBreaker<
+        failure_policy::OrElse<
+            SuccessRateOverTimeWindow<backoff::EqualJittered>,
+            ConsecutiveFailures<backoff::EqualJittered>,
+        >,
+        NoopInstrument,
+    >
+{
+    fn default() -> Self {
+        CircuitBreaker::builder().build()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@
 //! use std::time::Duration;
 //! use failsafe::{backoff, failure_policy, CircuitBreaker};
 //!
-//! // Create an exponential growth backoff which starts from 5s and ends with 60s.
+//! // Create an exponential growth backoff which starts from 10s and ends with 60s.
 //! let backoff = backoff::exponential(Duration::from_secs(10), Duration::from_secs(60));
 //!
 //! // Create a policy which failed when three consecutive failures were made.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@
 //!
 //! // Create a circuit breaker which configured by reasonable default backoff and
 //! // failure accrual policy.
-//! let circuit_breaker = CircuitBreaker::builder().build();
+//! let circuit_breaker = CircuitBreaker::default();
 //!
 //! // Call the function in a loop, after some iterations the circuit breaker will
 //! // be in a open state and reject next calls.


### PR DESCRIPTION
A shorter version `CircuitBreaker::default()` instead `CircuitBreaker::builder().build()`