### PR TITLE
chore(syncronization) : use parking_lot crate `Mutex`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,8 +70,8 @@ name = "failsafe"
 version = "0.2.0"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "spin 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -277,11 +277,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "spin"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "stable_deref_trait"
@@ -531,7 +526,6 @@ dependencies = [
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5f9776d6b986f77b35c6cf846c11ad986ff128fe0b2b63a3628e3755e8d3102d"
 "checksum smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "153ffa32fd170e9944f7e0838edf824a754ec4c1fc64746fcc9fe1f8fa602e5d"
-"checksum spin 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "37b5646825922b96b5d7d676b5bb3458a54498e96ed7b0ce09dc43a07038fea4"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum tokio 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "fbb6a6e9db2702097bfdfddcb09841211ad423b86c75b5ddaca1d62842ac492c"
 "checksum tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "881e9645b81c2ce95fcb799ded2c29ffb9f25ef5bef909089a420e5961dd8ccb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/dmexe/failsafe-rs"
 [dependencies]
 futures = "0.1"
 rand = "0.5"
-spin = { version = "0.4", default-features = false }
+parking_lot= "0.6.4"
 
 [dev-dependencies]
 tokio = "0.1.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@
 
 extern crate futures as lib_futures;
 extern crate rand;
-extern crate spin;
+extern crate parking_lot;
 
 #[cfg(test)]
 extern crate tokio;

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -2,7 +2,7 @@ use std::fmt::{self, Debug};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use spin::Mutex;
+use parking_lot::Mutex;
 
 use super::clock;
 use super::failure_policy::FailurePolicy;


### PR DESCRIPTION
Use the synchronization crate `parking_lot` instead of `spin`

The `Mutex` is also `no poison` and the benefits are:

- We can use `deadlock detection` on it
- It is fast 
- It used frequently in the Rust community (well-tested I would say)