### PR TITLE
add explicitly dyn definition to trait objects

### DIFF
--- a/src/backoff.rs
+++ b/src/backoff.rs
@@ -11,7 +11,7 @@ pub use rand::prelude::ThreadRng;
 const MAX_RETRIES: u32 = 30;
 
 /// A type alias for backoff strategy.
-pub type Backoff = Iterator<Item = Duration>;
+pub type Backoff = dyn Iterator<Item = Duration>;
 
 /// Creates a infinite stream of given `duration`
 pub fn constant(duration: Duration) -> Constant {

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,7 +33,7 @@ where
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match self {
             Error::Inner(ref err) => Some(err),
             _ => None,


### PR DESCRIPTION
It fixes warnings like: 

```
error: trait objects without an explicit `dyn` are deprecated
```