### PR TITLE
Release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ Improvements:
 * use spin lock instead `std::sync::Mutex`
 
 [Unreleased]: https://github.com/dmexe/failsafe-rs/compare/v1.2.0...master
-[1.1.1]: https://github.com/dmexe/failsafe-rs/compare/v1.1.0...v1.2.0
+[1.2.0]: https://github.com/dmexe/failsafe-rs/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/dmexe/failsafe-rs/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/dmexe/failsafe-rs/compare/v0.3.1...v1.0.0
 [0.3.1]: https://github.com/dmexe/failsafe-rs/compare/v0.3.0...v0.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ### [Unreleased]
 
+### [1.2.0] - 2022-08-22
+
+Added:
+* the `reset` method to the `StateMachine`, (thanks to https://github.com/eg-fxia)
+
 Breaking changes:
 * minimum rust version is 1.49
 
@@ -53,7 +58,8 @@ Improvements:
 * remove `tokio-timer` dependency.
 * use spin lock instead `std::sync::Mutex`
 
-[Unreleased]: https://github.com/dmexe/failsafe-rs/compare/v1.1.0...master
+[Unreleased]: https://github.com/dmexe/failsafe-rs/compare/v1.2.0...master
+[1.1.1]: https://github.com/dmexe/failsafe-rs/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/dmexe/failsafe-rs/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/dmexe/failsafe-rs/compare/v0.3.1...v1.0.0
 [0.3.1]: https://github.com/dmexe/failsafe-rs/compare/v0.3.0...v0.3.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "failsafe"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "criterion",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "failsafe"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Dmitry Galinsky <dima.exe@gmail.com>"]
 description = "A circuit breaker implementation"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ failure from constantly recurring, during maintenance, temporary external system
 system difficulties.
 
 * [https://martinfowler.com/bliki/CircuitBreaker.html](https://martinfowler.com/bliki/CircuitBreaker.html)
-* [Read documentation](https://docs.rs/failsafe/1.1.0/failsafe)
+* [Read documentation](https://docs.rs/failsafe/1.2.0/failsafe)
 
 # Features
 
@@ -25,7 +25,7 @@ system difficulties.
 Add this to your Cargo.toml:
 
 ```toml
-failsafe = "1.1.0"
+failsafe = "1.2.0"
 ```
 
 # Example


### PR DESCRIPTION
Added:
* the `reset` method to the `StateMachine`, (thanks to https://github.com/eg-fxia)

Breaking changes:
* minimum rust version is 1.49

Updates:
* `pin_project` has been updated to `0.12`
* `criterion` has been updated to `0.3.6`