### PR TITLE
export failure_predicate::Any

### DIFF
--- a/src/failure_predicate.rs
+++ b/src/failure_predicate.rs
@@ -14,6 +14,7 @@ where
     }
 }
 
+/// the Any predicate always returns true
 #[derive(Debug, Copy, Clone)]
 pub struct Any;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ pub use self::circuit_breaker::CircuitBreaker;
 pub use self::config::Config;
 pub use self::error::Error;
 pub use self::failure_policy::FailurePolicy;
-pub use self::failure_predicate::FailurePredicate;
+pub use self::failure_predicate::{Any, FailurePredicate};
 pub use self::instrument::Instrument;
 pub use self::state_machine::StateMachine;
 pub use self::windowed_adder::WindowedAdder;


### PR DESCRIPTION
You could re implement this type yourself but I don't see any reason why you would just want to export it. It's useful when using the other components of this library to build your own abstraction