### PR TITLE
fix clippy lints

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
     <<: *default_env
     <<: *default_steps
     docker:
-    - image: "cimg/rust:1.62"
+    - image: "cimg/rust:1.79"
 
   rust_nightly:
     <<: *default_env

--- a/benches/state_machine.rs
+++ b/benches/state_machine.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 
 use failsafe::{backoff, clock, failure_policy, StateMachine};
 
+#[allow(clippy::unit_arg)]
 fn consecutive_failures_policy(c: &mut Criterion) {
     let backoff = backoff::constant(Duration::from_secs(5));
     let policy = failure_policy::consecutive_failures(3, backoff);
@@ -19,6 +20,7 @@ fn consecutive_failures_policy(c: &mut Criterion) {
     });
 }
 
+#[allow(clippy::unit_arg)]
 fn success_rate_over_time_window_policy(c: &mut Criterion) {
     let backoff = backoff::constant(Duration::from_secs(5));
     let policy =

--- a/src/backoff.rs
+++ b/src/backoff.rs
@@ -225,7 +225,7 @@ mod tests {
     use rand::{RngCore, SeedableRng};
     use rand_xorshift::XorShiftRng;
 
-    const SEED: &'static [u8; 16] = &[1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2];
+    const SEED: &[u8; 16] = &[1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2];
     struct TestGenRage<T>(T);
 
     impl Default for TestGenRage<XorShiftRng> {

--- a/src/circuit_breaker.rs
+++ b/src/circuit_breaker.rs
@@ -88,14 +88,14 @@ mod tests {
                 Err(Error::Inner(true)) => {}
                 x => unreachable!("{:?}", x),
             }
-            assert_eq!(true, circuit_breaker.is_call_permitted());
+            assert!(circuit_breaker.is_call_permitted());
         }
 
         match circuit_breaker.call_with(is_err, || Err::<(), _>(false)) {
             Err(Error::Inner(false)) => {}
             x => unreachable!("{:?}", x),
         }
-        assert_eq!(false, circuit_breaker.is_call_permitted());
+        assert!(!circuit_breaker.is_call_permitted());
     }
 
     #[test]
@@ -103,7 +103,7 @@ mod tests {
         let circuit_breaker = new_circuit_breaker();
 
         circuit_breaker.call(|| Ok::<_, ()>(())).unwrap();
-        assert_eq!(true, circuit_breaker.is_call_permitted());
+        assert!(circuit_breaker.is_call_permitted());
     }
 
     #[test]
@@ -114,13 +114,13 @@ mod tests {
             Err(Error::Inner(())) => {}
             x => unreachable!("{:?}", x),
         }
-        assert_eq!(false, circuit_breaker.is_call_permitted());
+        assert!(!circuit_breaker.is_call_permitted());
 
         match circuit_breaker.call(|| Err::<(), _>(())) {
             Err(Error::Rejected) => {}
             x => unreachable!("{:?}", x),
         }
-        assert_eq!(false, circuit_breaker.is_call_permitted());
+        assert!(!circuit_breaker.is_call_permitted());
     }
 
     fn new_circuit_breaker() -> impl CircuitBreaker {

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -1,7 +1,7 @@
 use std::cell::Cell;
 use std::time::{Duration, Instant};
 
-thread_local!(static CLOCK: Cell<Option<*const MockClock>> = Cell::new(None));
+thread_local!(static CLOCK: Cell<Option<*const MockClock>> = const { Cell::new(None) });
 
 #[derive(Debug)]
 pub struct MockClock(Instant);

--- a/src/futures/mod.rs
+++ b/src/futures/mod.rs
@@ -183,7 +183,7 @@ mod tests {
         let future = circuit_breaker.call(future);
 
         future.await.unwrap();
-        assert_eq!(true, circuit_breaker.is_call_permitted());
+        assert!(circuit_breaker.is_call_permitted());
     }
 
     #[tokio::test]
@@ -196,7 +196,7 @@ mod tests {
             Err(Error::Inner(_)) => {}
             err => unreachable!("{:?}", err),
         }
-        assert_eq!(false, circuit_breaker.is_call_permitted());
+        assert!(!circuit_breaker.is_call_permitted());
 
         let future = delay_for(Duration::from_secs(1));
         let future = circuit_breaker.call(future);
@@ -204,7 +204,7 @@ mod tests {
             Err(Error::Rejected) => {}
             err => unreachable!("{:?}", err),
         }
-        assert_eq!(false, circuit_breaker.is_call_permitted());
+        assert!(!circuit_breaker.is_call_permitted());
     }
 
     #[tokio::test]
@@ -219,7 +219,7 @@ mod tests {
                 Err(Error::Inner(true)) => {}
                 err => unreachable!("{:?}", err),
             }
-            assert_eq!(true, circuit_breaker.is_call_permitted());
+            assert!(circuit_breaker.is_call_permitted());
         }
 
         let future = future::err::<(), _>(false);
@@ -228,7 +228,7 @@ mod tests {
             Err(Error::Inner(false)) => {}
             err => unreachable!("{:?}", err),
         }
-        assert_eq!(false, circuit_breaker.is_call_permitted());
+        assert!(!circuit_breaker.is_call_permitted());
     }
 
     fn new_circuit_breaker() -> impl CircuitBreaker {


### PR DESCRIPTION
Fixes all clippy lints, which were showing up as errors with `deny(warnings)`