### PR TITLE
Release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 ### [Unreleased]
 
+### [1.3.0] - 2024-05-05
+
+Added:
+* Implements circuit breaker for `futures::Stream` (thanks to https://github.com/leshow)
+
 Breaking changes:
 * minimum rust version is 1.59
-
 
 ### [1.2.0] - 2022-08-22
 
@@ -62,7 +66,8 @@ Improvements:
 * remove `tokio-timer` dependency.
 * use spin lock instead `std::sync::Mutex`
 
-[Unreleased]: https://github.com/dmexe/failsafe-rs/compare/v1.2.0...master
+[Unreleased]: https://github.com/dmexe/failsafe-rs/compare/v1.3.0...master
+[1.2.0]: https://github.com/dmexe/failsafe-rs/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/dmexe/failsafe-rs/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/dmexe/failsafe-rs/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/dmexe/failsafe-rs/compare/v0.3.1...v1.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "failsafe"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "criterion",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "failsafe"
-version = "1.2.0"
+version = "1.3.0"
 authors = ["Dmitry Galinsky <dima.exe@gmail.com>"]
 description = "A circuit breaker implementation"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ failure from constantly recurring, during maintenance, temporary external system
 system difficulties.
 
 * [https://martinfowler.com/bliki/CircuitBreaker.html](https://martinfowler.com/bliki/CircuitBreaker.html)
-* [Read documentation](https://docs.rs/failsafe/1.2.0/failsafe)
+* [Read documentation](https://docs.rs/failsafe/1.3.0/failsafe)
 
 # Features
 
@@ -25,7 +25,7 @@ system difficulties.
 Add this to your Cargo.toml:
 
 ```toml
-failsafe = "1.2.0"
+failsafe = "1.3.0"
 ```
 
 # Example


### PR DESCRIPTION
Added:
* Implements circuit breaker for `futures::Stream` (thanks to https://github.com/leshow)

Breaking changes:
* minimum rust version is 1.59